### PR TITLE
Add early-access workflow for pre-release builds

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -1,0 +1,103 @@
+name: early-access
+
+on:
+  workflow_dispatch:
+    inputs:
+      currentDevelopmentVersion:
+        description: 'The current development version'
+        required: true
+
+jobs:
+  pre-release-build:
+    name: Build Pre-release Artifacts
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+    steps:
+      - name: Checkout Wanaku Main Project
+        uses: actions/checkout@v4
+        with:
+          repository: wanaku-ai/wanaku
+          persist-credentials: false
+          ref: main
+          path: wanaku
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build Wanaku Main Project
+        run: mvn --no-transfer-progress -DskipTests clean install
+        working-directory: ${{ github.workspace }}/wanaku
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set arch
+        id: arch
+        run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Create a snapshot build with container push (x86)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mvn --no-transfer-progress -Pdist \
+          -Dquarkus.container-image.build=true \
+          -Dquarkus.container-image.push=true \
+          -Dquarkus.container-image.tag=${{ github.event.inputs.currentDevelopmentVersion }}-${{ steps.arch.outputs.arch }} \
+          -Dquarkus.jib.platforms=linux/amd64 \
+          clean package
+      - name: Create a snapshot build with container push (arm)
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          mvn --no-transfer-progress -Pdist \
+          -Dquarkus.container-image.build=true \
+          -Dquarkus.container-image.push=true \
+          -Dquarkus.container-image.tag=${{ github.event.inputs.currentDevelopmentVersion }}-${{ steps.arch.outputs.arch }} \
+          -Dquarkus.jib.platforms=linux/arm64/v8 \
+          clean package
+      - name: Run JReleaser
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
+          JRELEASER_PROJECT_SNAPSHOT_LABEL: early-access
+          JRELEASER_SELECT_CURRENT_PLATFORM: true
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      # Persist logs
+
+      - name: JReleaser release output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jreleaser-release-${{ matrix.os }}
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties
+
+  createManifests:
+    needs: pre-release-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Create and push multi-arch manifests
+        run: |
+          ./build-manifests.sh ${{ github.event.inputs.currentDevelopmentVersion }}


### PR DESCRIPTION
## Summary
- Add a new `early-access.yml` GitHub Actions workflow for pre-release builds
- Triggered manually via `workflow_dispatch` with a `currentDevelopmentVersion` input
- Builds multi-arch (x86 + ARM) container images and pushes to Quay.io
- Creates a pre-release GitHub release via JReleaser with the `early-access` snapshot label
- Creates multi-arch Docker manifests after build completes

## Test plan
- [ ] Trigger the workflow manually with a development version (e.g., `0.1.0-SNAPSHOT`)
- [ ] Verify container images are pushed to Quay.io with the correct tags
- [ ] Verify JReleaser creates an early-access pre-release on GitHub
- [ ] Verify multi-arch manifests are created correctly