### PR TITLE
Fix early-access JReleaser race condition

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -66,6 +66,7 @@ jobs:
           -Dquarkus.jib.platforms=linux/arm64/v8 \
           clean package
       - name: Run JReleaser
+        if: matrix.os == 'ubuntu-latest'
         uses: jreleaser/release-action@v2
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,10 +80,10 @@ jobs:
       # Persist logs
 
       - name: JReleaser release output
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: jreleaser-release-${{ matrix.os }}
+          name: jreleaser-release
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties


### PR DESCRIPTION
## Summary
- Run JReleaser only on `ubuntu-latest` (not on both matrix runners)
- Both matrix runners were uploading the same platform-independent Java binary artifacts to the same `early-access` release simultaneously, causing a 404 on the GitHub "update release asset" API
- The ARM runner only needs to build and push its container image; it doesn't need to run JReleaser

## Test plan
- [ ] Run `gh workflow run early-access -f currentDevelopmentVersion=0.1.0-SNAPSHOT` and verify all jobs pass