### PR TITLE
Add missing distributions and containers

### DIFF
--- a/containers.txt
+++ b/containers.txt
@@ -1,7 +1,9 @@
 quay.io/wanaku/wanaku-tool-service-duckduckgo:latest
 quay.io/wanaku/wanaku-tool-service-jira:latest
-quay.io/wanaku/wanaku-tool-service-yaml-route:latest
 quay.io/wanaku/wanaku-tool-service-kafka:latest
-quay.io/wanaku/wanaku-provider-s3:latest
-quay.io/wanaku/wanaku-provider-ftp:latest
+quay.io/wanaku/wanaku-tool-service-sqs:latest
+quay.io/wanaku/wanaku-tool-service-telegram:latest
+quay.io/wanaku/wanaku-tool-service-yaml-route:latest
 quay.io/wanaku/wanaku-provider-file:latest
+quay.io/wanaku/wanaku-provider-ftp:latest
+quay.io/wanaku/wanaku-provider-s3:latest

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -36,10 +36,38 @@ release:
 
 distributions:
   wanaku-tool-service-duckduckgo:
+    type: JAVA_BINARY
     artifacts:
       - path: tools/wanaku-tool-service-duckduckgo/target/distributions/wanaku-tool-service-duckduckgo-{{projectVersion}}.zip
-    type: JAVA_BINARY
   wanaku-tool-service-jira:
+    type: JAVA_BINARY
     artifacts:
       - path: tools/wanaku-tool-service-jira/target/distributions/wanaku-tool-service-jira-{{projectVersion}}.zip
+  wanaku-tool-service-kafka:
     type: JAVA_BINARY
+    artifacts:
+      - path: tools/wanaku-tool-service-kafka/target/distributions/wanaku-tool-service-kafka-{{projectVersion}}.zip
+  wanaku-tool-service-sqs:
+    type: JAVA_BINARY
+    artifacts:
+      - path: tools/wanaku-tool-service-sqs/target/distributions/wanaku-tool-service-sqs-{{projectVersion}}.zip
+  wanaku-tool-service-telegram:
+    type: JAVA_BINARY
+    artifacts:
+      - path: tools/wanaku-tool-service-telegram/target/distributions/wanaku-tool-service-telegram-{{projectVersion}}.zip
+  wanaku-tool-service-yaml-route:
+    type: JAVA_BINARY
+    artifacts:
+      - path: tools/wanaku-tool-service-yaml-route/target/distributions/wanaku-tool-service-yaml-route-{{projectVersion}}.zip
+  wanaku-provider-file:
+    type: JAVA_BINARY
+    artifacts:
+      - path: providers/wanaku-provider-file/target/distributions/wanaku-provider-file-{{projectVersion}}.zip
+  wanaku-provider-ftp:
+    type: JAVA_BINARY
+    artifacts:
+      - path: providers/wanaku-provider-ftp/target/distributions/wanaku-provider-ftp-{{projectVersion}}.zip
+  wanaku-provider-s3:
+    type: JAVA_BINARY
+    artifacts:
+      - path: providers/wanaku-provider-s3/target/distributions/wanaku-provider-s3-{{projectVersion}}.zip


### PR DESCRIPTION
## Summary
- Add 7 missing distributions to `jreleaser.yml`: kafka, sqs, telegram, yaml-route, provider-file, provider-ftp, provider-s3
- Add 2 missing containers to `containers.txt`: sqs and telegram
- Note: `aws-security-tool` is excluded from both as it has neither assembly descriptors nor container image configuration

## Test plan
- [ ] Merge and re-run early-access workflow
- [ ] Verify all 9 distribution zips appear as release assets
- [ ] Verify multi-arch manifests are created for all 9 containers