### PR TITLE
Add scheduled daily trigger for early-access builds

### DIFF
--- a/.github/workflows/generate-early-access.yml
+++ b/.github/workflows/generate-early-access.yml
@@ -1,0 +1,28 @@
+name: Generate Early Access
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  trigger-early-access:
+    if: github.repository == 'wanaku-ai/wanaku-examples'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from pom.xml
+        id: version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger early-access workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run early-access.yml \
+            -f currentDevelopmentVersion=${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- Adds a `generate-early-access.yml` workflow that runs daily at 00:00 UTC
- Extracts the current development version from `pom.xml` and triggers the existing `early-access.yml` workflow
- Also supports manual dispatch via `workflow_dispatch`
- Mirrors the pattern from wanaku-ai/wanaku#857

## Test plan
- [ ] Verify the workflow appears in the Actions tab
- [ ] Trigger manually via `workflow_dispatch` to confirm it dispatches the early-access workflow correctly