### PR TITLE
chore: fix generate-early-access workflow

### DIFF
--- a/.github/workflows/generate-early-access.yml
+++ b/.github/workflows/generate-early-access.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Extract version from pom.xml
         id: version
         run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Trigger early-access workflow


### PR DESCRIPTION
## Summary

- The `generate-early-access.yml` workflow was failing because it used `mvn help:evaluate` to extract the project version, but Maven was not installed on the runner
- Even with Maven installed, the parent POM (`ai.wanaku:parent`) is not in Maven Central, so resolution would fail without building the parent first
- Replaced with a simple `grep`/`sed` extraction from `pom.xml`, which requires no additional tooling

## Test plan

- [ ] Trigger the `Generate Early Access` workflow manually and verify it succeeds
- [ ] Verify the extracted version is correct (`0.1.0-SNAPSHOT`)