### PR TITLE
chore: add actions:write permission to generate-early-access workflow

### DIFF
--- a/.github/workflows/generate-early-access.yml
+++ b/.github/workflows/generate-early-access.yml
@@ -6,6 +6,10 @@ on:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   trigger-early-access:
     if: github.repository == 'wanaku-ai/wanaku-examples'


### PR DESCRIPTION
## Summary

- The `generate-early-access` workflow fails with `HTTP 403: Resource not accessible by integration` when calling `gh workflow run`
- The `GITHUB_TOKEN` needs `actions: write` permission to dispatch workflow events
- Adds top-level `permissions` block with `actions: write` and `contents: read`

## Test plan

- [ ] Trigger the `Generate Early Access` workflow manually and verify it successfully dispatches the `early-access` workflow