### PR TITLE
chore: rename capability artifactIds to match wanaku#921

### DIFF
--- a/mcp-servers/aws-security-tool/pom.xml
+++ b/mcp-servers/aws-security-tool/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-forward-discovery</artifactId>
+            <artifactId>wanaku-mcp-forward-discovery</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/providers/wanaku-provider-file/pom.xml
+++ b/providers/wanaku-provider-file/pom.xml
@@ -20,19 +20,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-provider</artifactId>
+            <artifactId>wanaku-capabilities-provider</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/providers/wanaku-provider-ftp/pom.xml
+++ b/providers/wanaku-provider-ftp/pom.xml
@@ -20,19 +20,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-provider</artifactId>
+            <artifactId>wanaku-capabilities-provider</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/providers/wanaku-provider-s3/pom.xml
+++ b/providers/wanaku-provider-s3/pom.xml
@@ -19,19 +19,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-provider</artifactId>
+            <artifactId>wanaku-capabilities-provider</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-duckduckgo/pom.xml
+++ b/tools/wanaku-tool-service-duckduckgo/pom.xml
@@ -39,19 +39,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-jira/pom.xml
+++ b/tools/wanaku-tool-service-jira/pom.xml
@@ -52,13 +52,13 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${wanaku.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-kafka/pom.xml
+++ b/tools/wanaku-tool-service-kafka/pom.xml
@@ -20,19 +20,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-sqs/pom.xml
+++ b/tools/wanaku-tool-service-sqs/pom.xml
@@ -40,19 +40,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-telegram/pom.xml
+++ b/tools/wanaku-tool-service-telegram/pom.xml
@@ -40,13 +40,13 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -58,7 +58,7 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/tools/wanaku-tool-service-yaml-route/pom.xml
+++ b/tools/wanaku-tool-service-yaml-route/pom.xml
@@ -20,19 +20,19 @@
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-base</artifactId>
+            <artifactId>wanaku-capabilities-base</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-capabilities-tool</artifactId>
+            <artifactId>wanaku-capabilities-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>ai.wanaku</groupId>
-            <artifactId>core-runtime-camel</artifactId>
+            <artifactId>wanaku-capabilities-runtime-camel</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Updates all dependency references to match the artifact renames from wanaku-ai/wanaku#921
- Affected artifactIds: `core-capabilities-base` → `wanaku-capabilities-base`, `core-capabilities-provider` → `wanaku-capabilities-provider`, `core-capabilities-tool` → `wanaku-capabilities-tools`, `core-forward-discovery` → `wanaku-mcp-forward-discovery`, `core-runtime-camel` → `wanaku-capabilities-runtime-camel`

## Test plan

- [ ] Full CI build passes after wanaku#921 is merged