### PR TITLE
chore: enable shared HTTP listener for gRPC capabilities

### DIFF
--- a/providers/wanaku-provider-file/src/main/resources/application.properties
+++ b/providers/wanaku-provider-file/src/main/resources/application.properties
@@ -1,11 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9002
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9002
+# %test.quarkus.grpc.server.port=9002
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-%dev.quarkus.grpc.server.port=9002
-%test.quarkus.grpc.server.port=9002
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -18,7 +29,9 @@ wanaku.service.service.defaults.noop=true
 wanaku.service.service.defaults.idempotent=false
 
 # Registration settings
-# wanaku.service.registration.uri=http://localhost:8080
-# wanaku.service.registration.interval=10s
-# wanaku.service.registration.retries=3
-# wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/providers/wanaku-provider-ftp/src/main/resources/application.properties
+++ b/providers/wanaku-provider-ftp/src/main/resources/application.properties
@@ -1,12 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9004
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9004
+# %test.quarkus.grpc.server.port=9004
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9004
-%test.quarkus.grpc.server.port=9004
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -16,8 +26,10 @@ quarkus.log.category."ai.wanaku".level=INFO
 wanaku.service.name=ftp
 wanaku.service.base-uri=ftp://
 
-# Registration options
-# wanaku.service.registration.uri=http://localhost:8080
-# wanaku.service.register-delay-seconds=3
-# wanaku.service.register-retries=3
-# wanaku.service.register-retry-wait-seconds=1
+# Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/providers/wanaku-provider-s3/src/main/resources/application.properties
+++ b/providers/wanaku-provider-s3/src/main/resources/application.properties
@@ -1,12 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9005
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9005
+# %test.quarkus.grpc.server.port=9005
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9005
-%test.quarkus.grpc.server.port=9005
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -16,8 +26,10 @@ quarkus.log.category."ai.wanaku".level=INFO
 wanaku.service.name=aws2-s3
 wanaku.service.base-uri=aws2-s3://
 
-# Registration options
-# wanaku.service.registration.uri=http://localhost:8080
-# wanaku.service.register-delay-seconds=3
-# wanaku.service.register-retries=3
-# wanaku.service.register-retry-wait-seconds=1
+# Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
+#wanaku.service.registration.interval=10s
+#wanaku.service.registration.retries=3
+#wanaku.service.registration.retry-wait-seconds=1
+#wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-duckduckgo/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-duckduckgo/src/main/resources/application.properties
@@ -14,14 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
+quarkus.console.enabled = false
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -37,7 +48,9 @@ wanaku.service.service.properties[0].description=The search terms for the DuckDu
 wanaku.service.service.properties[0].required=true
 
 # Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
 #wanaku.service.registration.interval=10s
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-jira/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-jira/src/main/resources/application.properties
@@ -14,14 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
+quarkus.console.enabled = false
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -37,7 +48,9 @@ wanaku.service.service.properties[0].description=The issue to fetch
 wanaku.service.service.properties[0].required=true
 
 # Registration settings
+#wanaku.service.registration.uri=http://localhost:8080
 #wanaku.service.registration.interval=10s
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-kafka/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-kafka/src/main/resources/application.properties
@@ -1,12 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9003
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9003
+# %test.quarkus.grpc.server.port=9003
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick a unique port
-%dev.quarkus.grpc.server.port=9003
-%test.quarkus.grpc.server.port=9003
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -27,3 +37,4 @@ wanaku.service.service.properties[0].required=true
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-sqs/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-sqs/src/main/resources/application.properties
@@ -1,12 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9011
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9011
+# %test.quarkus.grpc.server.port=9011
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9011
-%test.quarkus.grpc.server.port=9011
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -33,3 +43,4 @@ wanaku.service.service.properties[0].required=true
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-telegram/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-telegram/src/main/resources/application.properties
@@ -1,12 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9007
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9007
+# %test.quarkus.grpc.server.port=9007
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-# If running multiple services on the same host, then you must pick an unique port
-%dev.quarkus.grpc.server.port=9007
-%test.quarkus.grpc.server.port=9007
 
 wanaku.service.name=telegram://bots
 
@@ -35,3 +45,4 @@ wanaku.service.service.properties[1].required=true
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr

--- a/tools/wanaku-tool-service-yaml-route/src/main/resources/application.properties
+++ b/tools/wanaku-tool-service-yaml-route/src/main/resources/application.properties
@@ -1,11 +1,22 @@
-quarkus.http.host-enabled=false
+# HTTP Server Configuration
+# When use-separate-server=false, gRPC shares the HTTP listener and http.host-enabled must be true
+quarkus.http.host-enabled=true
+quarkus.http.port=9001
+quarkus.http.host=0.0.0.0
+
+# gRPC Server Configuration
+# Set to false to share the HTTP listener (recommended for simpler deployment)
+# Set to true for a separate gRPC server (requires quarkus.grpc.server.port)
+quarkus.grpc.server.use-separate-server=false
+
+# Only needed when use-separate-server=true
+# quarkus.grpc.server.host=0.0.0.0
+# %dev.quarkus.grpc.server.port=9001
+# %test.quarkus.grpc.server.port=9001
+
 quarkus.banner.enabled = false
 quarkus.devservices.enabled = false
 quarkus.console.enabled = false
-
-quarkus.grpc.server.host=0.0.0.0
-%dev.quarkus.grpc.server.port=9001
-%test.quarkus.grpc.server.port=9001
 
 quarkus.log.level=WARNING
 quarkus.log.category."ai.wanaku".level=INFO
@@ -26,3 +37,4 @@ wanaku.service.service.properties[0].required=true
 #wanaku.service.registration.retry-wait-seconds=1
 #wanaku.service.registration.retries=3
 #wanaku.service.registration.delay-seconds=3
+#wanaku.service.registration.announce-address=my-custom-addr


### PR DESCRIPTION
## Summary

- Align with wanaku-ai/wanaku#1013 by switching all tool services and providers from separate gRPC servers to the shared HTTP listener mode
- Enable `quarkus.http.host-enabled=true` and set `quarkus.grpc.server.use-separate-server=false` across all 9 capability services
- Add `announce-address` to registration settings and normalize property names

## Test plan

- [ ] Build the project with `mvn -Pdist clean package`
- [ ] Verify capabilities register correctly with the router using the shared HTTP listener