### PR TITLE
Support releases from version branches

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -18,12 +18,22 @@ jobs:
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
     steps:
+      - name: Determine Wanaku ref
+        id: wanaku-ref
+        shell: bash
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          if git ls-remote --heads https://github.com/wanaku-ai/wanaku.git "$BRANCH" | grep -q .; then
+            echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "ref=main" >> $GITHUB_OUTPUT
+          fi
       - name: Checkout Wanaku Main Project
         uses: actions/checkout@v4
         with:
           repository: wanaku-ai/wanaku
           persist-credentials: false
-          ref: main
+          ref: ${{ steps.wanaku-ref.outputs.ref }}
           path: wanaku
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - main
       - release-prep
+      - '[0-9]*.[0-9]*.x'
     tags:
       - wanaku-*
 
@@ -27,12 +28,22 @@ jobs:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Determine Wanaku ref
+      id: wanaku-ref
+      shell: bash
+      run: |
+        BRANCH="${GITHUB_REF_NAME}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
     - name: Checkout Wanaku Main project
       uses: actions/checkout@v4
       with:
         repository: wanaku-ai/wanaku
         persist-credentials: false
-        ref: main
+        ref: ${{ steps.wanaku-ref.outputs.ref }}
         path: wanaku
     - name: Set up JDK 21
       uses: actions/setup-java@v4
@@ -45,7 +56,6 @@ jobs:
       working-directory: ${{ github.workspace }}/wanaku
     - uses: actions/checkout@v4
       with:
-        ref: main
         persist-credentials: false
         fetch-depth: 0
     - name: Set arch

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,9 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - '[0-9]*.[0-9]*.x'
 
 env:
   PROJECTS: ${{ github.workspace }}
@@ -30,12 +32,22 @@ jobs:
       fail-fast: true
 
     steps:
+    - name: Determine Wanaku ref
+      id: wanaku-ref
+      shell: bash
+      run: |
+        BRANCH="${{ github.base_ref }}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
     - name: Checkout Wanaku Main project
       uses: actions/checkout@v4
       with:
         repository: wanaku-ai/wanaku
         persist-credentials: false
-        ref: main
+        ref: ${{ steps.wanaku-ref.outputs.ref }}
         path: wanaku
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       releaseVersion:
         description: 'The release version (e.g.: 0.1.0)'
         required: true
+      releaseBranch:
+        description: 'The release branch (e.g., 0.2.x)'
+        required: true
 
 jobs:
   create-branch:
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.releaseBranch }}
 
       - name: Create and push release branch
         run: |
@@ -104,6 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.releaseVersion }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -8,17 +8,20 @@ Via the GitHub UI:
 
 1. Go to **Actions** > **release** > **Run workflow**.
 2. Enter the release version (e.g., `0.1.0`).
-3. Click **Run workflow**.
+3. Enter the release branch (e.g., `main` or `0.2.x`).
+4. Click **Run workflow**.
 
 Via the CLI:
 
 ```shell
 export RELEASE_VERSION=0.1.1
-gh workflow run release -f releaseVersion=${RELEASE_VERSION}
+export RELEASE_BRANCH=0.1.x
+gh workflow run release -f releaseVersion=${RELEASE_VERSION} -f releaseBranch=${RELEASE_BRANCH}
 ```
 
 The workflow will:
 
+- Check out the specified release branch.
 - Create a branch named after the version (e.g., `0.1.0`).
 - Build the project with the `dist` profile.
 - Build and push container images for x86 and arm64 to Quay.io.
@@ -29,15 +32,17 @@ The workflow will:
 
 If you need to release manually, follow these steps:
 
-#### **1. Set the version**
+#### **1. Set the version and branch**
 
 ```shell
 export RELEASE_VERSION=0.1.0
+export RELEASE_BRANCH=0.1.x
 ```
 
 #### **2. Create the release branch**
 
 ```shell
+git checkout ${RELEASE_BRANCH}
 git checkout -b ${RELEASE_VERSION}
 git push origin ${RELEASE_VERSION}
 ```


### PR DESCRIPTION
## Summary

- Add `releaseBranch` input to the release workflow so releases can be cut from version branches (e.g., `0.2.x`) instead of only from `main`
- Add `[0-9]*.[0-9]*.x` branch pattern to `main-build.yml` push triggers and `maven.yml` PR targets
- Add Wanaku ref detection to `early-access.yml`, `main-build.yml`, and `maven.yml` so CI builds against the matching Wanaku branch when one exists, falling back to `main`
- Fix `createManifests` job in `release.yml` to check out the release version branch

## Test plan

- [ ] Dispatch the release workflow with `releaseBranch: 0.2.x` and verify it checks out from the correct branch
- [ ] Push to a `0.2.x` branch and verify `main-build.yml` triggers and resolves the correct Wanaku ref
- [ ] Open a PR targeting `0.2.x` and verify `maven.yml` triggers and builds against the matching Wanaku branch