### PR TITLE
Version bump parent references to Wanaku 0.3.0-SNAPSHOT

### DIFF
--- a/mcp-servers/aws-security-tool/pom.xml
+++ b/mcp-servers/aws-security-tool/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>mcp-servers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>         
     
     <artifactId>aws-security-tool</artifactId>

--- a/mcp-servers/pom.xml
+++ b/mcp-servers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </licenses>
 
     <properties>
-        <wanaku.version>0.2.0-SNAPSHOT</wanaku.version>
+        <wanaku.version>0.3.0-SNAPSHOT</wanaku.version>
         <awssdk.version>2.39.6</awssdk.version>
     </properties>
 

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/wanaku-provider-file/pom.xml
+++ b/providers/wanaku-provider-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-file</artifactId>

--- a/providers/wanaku-provider-ftp/pom.xml
+++ b/providers/wanaku-provider-ftp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-ftp</artifactId>

--- a/providers/wanaku-provider-s3/pom.xml
+++ b/providers/wanaku-provider-s3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-s3</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tools/wanaku-tool-service-duckduckgo/pom.xml
+++ b/tools/wanaku-tool-service-duckduckgo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-duckduckgo</artifactId>

--- a/tools/wanaku-tool-service-jira/pom.xml
+++ b/tools/wanaku-tool-service-jira/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-jira</artifactId>

--- a/tools/wanaku-tool-service-kafka/pom.xml
+++ b/tools/wanaku-tool-service-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-kafka</artifactId>

--- a/tools/wanaku-tool-service-sqs/pom.xml
+++ b/tools/wanaku-tool-service-sqs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-sqs</artifactId>

--- a/tools/wanaku-tool-service-telegram/pom.xml
+++ b/tools/wanaku-tool-service-telegram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-telegram</artifactId>

--- a/tools/wanaku-tool-service-yaml-route/pom.xml
+++ b/tools/wanaku-tool-service-yaml-route/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-yaml-route</artifactId>


### PR DESCRIPTION
## Summary
- Bumps all parent version references from `0.2.0-SNAPSHOT` to `0.3.0-SNAPSHOT` across 14 pom.xml files
- Completes the version bump started in 122d7fd which updated `wanaku.version` property but missed the parent references

## Test plan
- [x] Full `mvn compile` passes with all 14 modules