### PR TITLE
Fix version bump command in release guide

### DIFF
--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -28,6 +28,15 @@ The workflow will:
 - Run JReleaser to publish the release artifacts on GitHub.
 - Create and push multi-arch container manifests.
 
+### **Version Bump**
+
+To update all modules to a new Wanaku version:
+
+```shell
+export NEW_VERSION=0.3.0-SNAPSHOT
+mvn versions:update-parent -DparentVersion=${NEW_VERSION} -DgenerateBackupPoms=false && mvn versions:update-child-modules -DgenerateBackupPoms=false && mvn versions:set-property -Dproperty=wanaku.version -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
+```
+
 ### **Manual Release**
 
 If you need to release manually, follow these steps:

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -34,7 +34,7 @@ To update all modules to a new Wanaku version:
 
 ```shell
 export NEW_VERSION=0.3.0-SNAPSHOT
-mvn versions:update-parent -DparentVersion=${NEW_VERSION} -DgenerateBackupPoms=false && mvn versions:update-child-modules -DgenerateBackupPoms=false && mvn versions:set-property -Dproperty=wanaku.version -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
+mvn versions:update-parent -DparentVersion=${NEW_VERSION} -DgenerateBackupPoms=false && mvn versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false && mvn versions:set-property -Dproperty=wanaku.version -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
 ```
 
 ### **Manual Release**

--- a/mcp-servers/aws-security-tool/pom.xml
+++ b/mcp-servers/aws-security-tool/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>mcp-servers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>         
     
     <artifactId>aws-security-tool</artifactId>

--- a/mcp-servers/pom.xml
+++ b/mcp-servers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>ai.wanaku</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </licenses>
 
     <properties>
-        <wanaku.version>0.2.0-SNAPSHOT</wanaku.version>
+        <wanaku.version>0.3.0-SNAPSHOT</wanaku.version>
         <awssdk.version>2.39.6</awssdk.version>
     </properties>
 

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/wanaku-provider-file/pom.xml
+++ b/providers/wanaku-provider-file/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-file</artifactId>

--- a/providers/wanaku-provider-ftp/pom.xml
+++ b/providers/wanaku-provider-ftp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-ftp</artifactId>

--- a/providers/wanaku-provider-s3/pom.xml
+++ b/providers/wanaku-provider-s3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>providers</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-provider-s3</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>wanaku-examples</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tools/wanaku-tool-service-duckduckgo/pom.xml
+++ b/tools/wanaku-tool-service-duckduckgo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-duckduckgo</artifactId>

--- a/tools/wanaku-tool-service-jira/pom.xml
+++ b/tools/wanaku-tool-service-jira/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-jira</artifactId>

--- a/tools/wanaku-tool-service-kafka/pom.xml
+++ b/tools/wanaku-tool-service-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-kafka</artifactId>

--- a/tools/wanaku-tool-service-sqs/pom.xml
+++ b/tools/wanaku-tool-service-sqs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-sqs</artifactId>

--- a/tools/wanaku-tool-service-telegram/pom.xml
+++ b/tools/wanaku-tool-service-telegram/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-telegram</artifactId>

--- a/tools/wanaku-tool-service-yaml-route/pom.xml
+++ b/tools/wanaku-tool-service-yaml-route/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ai.wanaku.examples</groupId>
         <artifactId>tools</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>wanaku-tool-service-yaml-route</artifactId>


### PR DESCRIPTION
## Summary
- Replaces `versions:update-child-modules` with `versions:set` in the version bump one-liner
- `update-child-modules` does not update all parent version references; `versions:set` correctly sets the project version and propagates to all child modules

## Test plan
- [x] Verified `versions:set` updates all 14 pom.xml parent references